### PR TITLE
Fixes calculator styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -72,3 +72,7 @@ code {
 table.pure-table th, table.pure-table td {
   padding: 3px 5px 3px 5px;
 }
+
+.pure-form-aligned .pure-control-group label {
+  width: 15em;
+}


### PR DESCRIPTION
Fixes the current styling ugliness introduced in #28.

![22-50-ant4k-xozbu](https://cloud.githubusercontent.com/assets/10549158/18755661/0f7719e6-80bb-11e6-90ed-14376a73433f.jpg)


@jamiemtdwyer @Busfox 