### PR TITLE
Fix for billing address label

### DIFF
--- a/request_fields.yml
+++ b/request_fields.yml
@@ -100,7 +100,7 @@
   placeholder: "Shopify Toronto"
 -
   key: x_customer_billing_address1
-  name: x_customer_billing_address
+  name: x_customer_billing_address1
   placeholder: "241 Spadina Ave"
 -
   key: x_customer_billing_address2


### PR DESCRIPTION
Billing address labels are currently `x_customer_billing_address` and `x_customer_billing_address2`, whereas shipping address labels are `x_customer_shipping_address1` and `x_customer_shipping_address2`.

When using the simulator, this lead to a little confusion about the actual field name, and I discovered the field name and label were inconsistent.

This PR updates the label to match the key so that when developers are looking at the simulator they're seeing the accurate key names.
