### PR TITLE
Adding hosted-payment-sim.myshopify.io to dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -34,6 +34,8 @@ railgun:
   disk: 2G
   proxy:
     hosted-payment-sim.myshopify.io: 20000
+  hostnames:
+    - hosted-payment-sim.myshopify.io
 
 packages:
   - git@github.com:Shopify/dev-shopify.git


### PR DESCRIPTION
In order to easily test HPSDK in development, I wrote up https://vault.shopify.com/payments/Hosted-Payments-SDK and realized that the URL wasn't mapping to the simulator properly. This corrects that.

🎩 :
Try accessing https://hosted-payment-sim.myshopify.io on `master` then on this branch. (don't forget to `dev up` in between.

@pi3r @jordanliddle 