### PR TITLE
add support for order management notification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,5 +49,8 @@ DEPENDENCIES
   rack-test
   sinatra
 
+RUBY VERSION
+   ruby 2.1.8p440
+
 BUNDLED WITH
-   1.11.2
+   1.15.0

--- a/app.rb
+++ b/app.rb
@@ -60,21 +60,11 @@ class OffsiteGatewaySim < Sinatra::Base
     }
   end
 
-  post '/capture' do
+  post %r{/(capture|refund|void)} do |action|
     content_type :json
 
     if signature_valid?
-      200
-    else
-      [401, {}, { x_status: 'failed', x_error_message: 'Invalid signature' }.to_json]
-    end
-  end
-
-  post '/refund' do
-    content_type :json
-
-    if signature_valid?
-      [200, {}, fields.merge(x_status: 'success',
+      [200, {}, fields.merge(x_result: 'pending',
                              x_gateway_reference: SecureRandom.hex,
                              x_timestamp: Time.now.utc.iso8601).to_json]
     else
@@ -82,7 +72,11 @@ class OffsiteGatewaySim < Sinatra::Base
     end
   end
 
-  post '/execute/:action' do |action|
+  get '/notification' do
+    erb :notification
+  end
+
+  post '/execute/?:action?' do |action|
     ts = Time.now.utc.iso8601
     payload = {
       'x_account_id'        => fields['x_account_id'],
@@ -93,27 +87,34 @@ class OffsiteGatewaySim < Sinatra::Base
       'x_result'            => action,
       'x_gateway_reference' => SecureRandom.hex,
       'x_timestamp'         => ts
-      }
+    }
+    %w(x_transaction_type x_message x_result).each do |field|
+      payload[field] = fields[field] if fields[field]
+    end
+
     if action == "failed"
       payload['x_message'] = "This is a custom error message."
     end
     payload['x_signature'] = sign(payload)
     result = {timestamp: ts}
-    redirect_url = Addressable::URI.parse(fields['x_url_complete'])
-    redirect_url.query_values = payload
+    redirect_url = if fields['x_url_complete']
+      uri = Addressable::URI.parse(fields['x_url_complete'])
+      uri.query_values = payload
+      uri
+    end
+
     if request.params['fire_callback'] == 'true'
       callback_url = fields['x_url_callback']
       response = HTTParty.post(callback_url, body: payload)
       if response.code == 200
-        result[:redirect] = redirect_url
+        result[:redirect] = redirect_url if redirect_url
       else
         result[:error] = response
       end
     else
-      result[:redirect] = redirect_url
+      result[:redirect] = redirect_url if redirect_url
     end
     result.to_json
   end
-
   run! if app_file == $0
 end

--- a/views/get.erb
+++ b/views/get.erb
@@ -5,4 +5,5 @@
     <br/>
     <span><strong>HMAC key</strong>: <code><%= key %></code></span>
   </p>
+  <p>You can also send capture/refund/void notifications by clicking <a href="notification">here</a></p>
 </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -31,6 +31,7 @@
     $('.tip').tipr();
     $('a.execute').on('click',function(){
       data = <%= fields.to_json %>
+      data.x_transaction_type = $('#transaction-type').val();
       action = $(this).attr('data-result')
       fire_callback = $(this).attr('data-callback')
       url = "execute/" + action + "?fire_callback=" + fire_callback

--- a/views/notification.erb
+++ b/views/notification.erb
@@ -1,0 +1,55 @@
+<div class="t-pad center">
+  <div class="pure-g">
+    <div class="pure-u-1-1">
+      <h2>Refund Notification</h2>
+      <form class="pure-form pure-form-aligned" method="post" action="/execute?fire_callback=true">
+        <fieldset>
+          <div class="pure-control-group">
+            <label for="x_account_id">x_account_id</label>
+            <input id="x_account_id" name="x_account_id" type="text">
+          </div>
+          <div class="pure-control-group">
+            <label for="x_reference">x_reference</label>
+            <input id="x_reference" name="x_reference" type="text">
+           </div>
+           <div class="pure-control-group">
+             <label for="x_currency">x_currency</label>
+             <input id="x_currency" name="x_currency" type="text" value="USD">
+            </div>
+            <div class="pure-control-group">
+              <label for="x_amount">x_amount</label>
+              <input id="x_amount" name="x_amount" type="text" placeholder="1.0">
+            </div>
+          <div class="pure-control-group">
+            <label for="x_transaction_type">x_transaction_type</label>
+            <select id="x_transaction_type" name="x_transaction_type">
+              <option name="authorization">authorization</option>
+              <option name="capture">capture</option>
+              <option name="refund">refund</option>
+              <option name="void">void</option>
+            </select>
+          </div>
+          <div class="pure-control-group">
+            <label for="x_result">x_result</label>
+            <select id="x_result" name="x_result">
+              <option name="completed">completed</option>
+              <option name="pending">pending</option>
+              <option name="failed">failed</option>
+            </select>
+          </div>
+          <div class="pure-control-group">
+            <label for="x_url_callback">x_url_callback</label>
+            <input id="x_url_callback" name="x_url_callback" type="text" placeholder="https://checkout.shopify.com/services/ping/notify_integration/<gateway>/<shop_id>">
+          </div>
+          <div class="pure-control-group">
+            <label for="x_message">x_message</label>
+            <input id="x_message" name="x_message" type="text">
+          </div>
+          <div class="pure-controls">
+            <button type="submit" class="pure-button pure-button-primary">Send refund notification</button>
+          </div>
+        </fieldset>
+      </form>
+    </div>
+  </div>
+</div>

--- a/views/post.erb
+++ b/views/post.erb
@@ -23,6 +23,13 @@
   </table>
 </div>
 <div class="t-pad center">
+  <b>Transaction type:</b>
+  <select id="transaction-type">
+    <option value="sale">Sale</option>
+    <option value="authorization">Authorization</option>
+  </select>
+</div>
+<div class="t-pad center">
   <a class="execute pure-button button-success button-small tip" data-result="completed" data-callback="true" href="javascript:void(0)" data-tip="fire callback, then redirect">
     success
     <i class="fa fa-phone-square fa-lg"></i>


### PR DESCRIPTION
Adds support for order management endpoint (capture/refund/void) and adds a view to send async notification.

**index:**
<img width="595" alt="screen shot 2017-07-26 at 3 04 55 pm" src="https://user-images.githubusercontent.com/330573/28638757-d509643a-7213-11e7-9258-6890a85f8404.png">
**notification:**
<img width="550" alt="screen shot 2017-07-26 at 3 05 00 pm" src="https://user-images.githubusercontent.com/330573/28638758-d62f2f2a-7213-11e7-9470-92e362ea4bd3.png">
